### PR TITLE
try teamsfx cli in yo-teams-tab

### DIFF
--- a/yo-teams-tab/.env.teamsfx
+++ b/yo-teams-tab/.env.teamsfx
@@ -1,0 +1,40 @@
+# The public domain name of where you host your application
+# TeamsFx uses localhost
+PUBLIC_HOSTNAME=localhost:3007
+
+# Id of the Microsoft Teams application
+APPLICATION_ID=ca1990f0-17c6-11ed-ae1f-17e65e2e6feb
+# Package name of the Microsoft Teams application
+PACKAGE_NAME=yoteamstab
+
+# App Id and App Password for the Bot Framework bot
+MICROSOFT_APP_ID=
+MICROSOFT_APP_PASSWORD=
+
+# Port for local debugging
+PORT=3007
+
+# Local SSL Certificate for local debugging
+# `teamsfx dev-cert` generates certificate to ${HOME}/.fx/certificate/
+HTTPS_SSL_CERT_PATH=
+HTTPS_SSL_KEY_PATH=
+
+# Security token for the default outgoing webhook
+SECURITY_TOKEN=
+
+# ID of the Outlook Connector
+CONNECTOR_ID=
+
+# Application Insights instrumentation key
+APPINSIGHTS_INSTRUMENTATIONKEY=
+
+# NGROK configuration for development
+# NGROK authentication token (leave empty for anonymous)
+NGROK_AUTH=
+# NGROK sub domain. ex "myapp" or  (leave empty for random)
+NGROK_SUBDOMAIN=
+# NGROK region. (us, eu, au, ap - default is us)
+NGROK_REGION=
+
+# Debug settings, default logging "msteams"
+DEBUG=msteams

--- a/yo-teams-tab/.vscode/launch.json
+++ b/yo-teams-tab/.vscode/launch.json
@@ -38,14 +38,19 @@
             ]
         },
         {
-            "name": "Launch client new (Edge)",
-            "type": "pwa-msedge",
+            "name": "Sideload in Teams (Chrome)",
+            "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/ca1990f0-17c6-11ed-ae1f-17e65e2e6feb?installAppPackage=true&webjoin=true",
             "outFiles": [
                 "${workspaceFolder}/dist/web/**/*.js",
                 "!**/node_modules/**"
-            ]
+            ],
+            "presentation": {
+                "group": "_teamsfx",
+                "order": 1
+            },
+            // "preLaunchTask": "Launch and Upload Teams App"
         },
     ],
     "compounds": [
@@ -70,19 +75,6 @@
             "presentation": {
                 "group": "all",
                 "order": 2
-            },
-            "stopAll": true
-        },
-        {
-            "name": "Debug new (Edge)",
-            "configurations": [
-                "Attach to server",
-                "Launch client new (Edge)"
-            ],
-            "preLaunchTask": "Pre Debug Check & Start All",
-            "presentation": {
-                "group": "all",
-                "order": 3
             },
             "stopAll": true
         }

--- a/yo-teams-tab/.vscode/tasks.json
+++ b/yo-teams-tab/.vscode/tasks.json
@@ -2,17 +2,17 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Pre Debug Check & Start All",
+            "label": "Launch and Upload Teams App",
             "dependsOn": [
-                "gulp ngrok-serve",
-                "upload teams manifest",
+                "Launch Local Server",
+                "Upload App Manifest",
             ],
             "dependsOrder": "sequence"
         },
         {
-            "label": "gulp ngrok-serve",
+            "label": "Launch Local Server",
             "type": "shell",
-            "command": "gulp ngrok-serve --debug",
+            "command": "npm run teamsfx:debug",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -32,22 +32,12 @@
             }
         },
         {
-            "label": "upload teams manifest",
+            "label": "Upload App Manifest",
             "type": "shell",
-            "command": "exit ${input:upload-teams-manifest}",
-            "presentation": {
-                "reveal": "never"
+            "command": "npm run teamsfx:upload-manifest",
+            "options": {
+                "cwd": "${workspaceFolder}"
             }
         },
-    ],
-    "inputs": [
-        {
-            "id": "upload-teams-manifest",
-            "type": "command",
-            "command": "fx-extension.debug-task-upload-teams-manifest",
-            "args": {
-                "manifestZipPackage": "${teamsfx:workspaceFolder}/package/tab.zip"
-            }
-        }
     ]
 }

--- a/yo-teams-tab/package.json
+++ b/yo-teams-tab/package.json
@@ -7,7 +7,10 @@
     "build": "gulp build",
     "manifest": "gulp manifest",
     "debug": "gulp serve --debug",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "teamsfx:dev-cert": "teamsfx dev-cert --trust",
+    "teamsfx:debug": "gulp serve --env=.env.teamsfx --debug",
+    "teamsfx:upload-manifest": "teamsfx manifest --upload --package-path package/yoteamstab.zip"
   },
   "dependencies": {
     "@fluentui/react-northstar": "~0.62.0",
@@ -27,6 +30,7 @@
     "msteams-react-base-component": "^4.0.1"
   },
   "devDependencies": {
+    "@microsoft/teamsfx-cli": "^1.0.5",
     "@types/debug": "4.1.7",
     "@types/express": "^4.17.13",
     "@types/express-session": "~1.17.4",

--- a/yo-teams-tab/src/server/server.ts
+++ b/yo-teams-tab/src/server/server.ts
@@ -1,5 +1,7 @@
 import * as Express from "express";
+import * as fs from "fs";
 import * as http from "http";
+import * as https from "https";
 import * as path from "path";
 import * as morgan from "morgan";
 import { MsTeamsApiRouter, MsTeamsPageRouter } from "express-msteams-host";
@@ -63,6 +65,17 @@ express.use("/", Express.static(path.join(__dirname, "web/"), {
 express.set("port", port);
 
 // Start the webserver
-http.createServer(express).listen(port, () => {
-    log(`Server running on ${port}`);
-});
+if (process.env.HTTPS_SSL_CERT_PATH && process.env.HTTPS_SSL_KEY_PATH) {
+    // HTTPS
+    const cert  = fs.readFileSync(process.env.HTTPS_SSL_CERT_PATH, 'utf8');
+    const key = fs.readFileSync(process.env.HTTPS_SSL_KEY_PATH, 'utf8');
+    const credentials = {cert: cert, key: key};
+    https.createServer(credentials, express).listen(port, () => {
+        log(`HTTPS Server running on ${port}`);
+    });
+} else {
+    // HTTP
+    http.createServer(express).listen(port, () => {
+        log(`Server running on ${port}`);
+    });
+}


### PR DESCRIPTION
Two commands that teamsfx-cli can provide (not provided yet):
- `teamsfx dev-cert` - to generate localhost ssl certificate (with `--trust` to add to user's trusted cert store)
- `teamsfx manifest --upload` - to upload app package (with `--package-path` to point to yoteamstab.zip)

These commands are added to package.json so developer can choose either to manually execute in terminal or insert into tasks.json to make one-click-f5 work.